### PR TITLE
Use a dot instead of underscore to separate the name and version.

### DIFF
--- a/upload-artifact.sh
+++ b/upload-artifact.sh
@@ -6,7 +6,7 @@ VERSION=$(grep "^version" ./threedi_api_qgis_client/metadata.txt | cut -d= -f2)
 
 # ARTIFACTS_KEY should be set as env variable in the travis UI.
 # TRAVIS_BRANCH is set automatically by travis
-ARTIFACT=threedi_api_qgis_client_${VERSION}.zip
+ARTIFACT=threedi_api_qgis_client.${VERSION}.zip
 PROJECT=threedi-api-qgis-client
 
 curl -X POST \

--- a/zip_plugin.py
+++ b/zip_plugin.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     plugin_dirname = "threedi_api_qgis_client"
     plugin_path = os.path.join(this_dir, plugin_dirname)
     plugin_version = get_version(plugin_path)
-    zip_filename = f"{plugin_dirname}_{plugin_version}"
+    zip_filename = f"{plugin_dirname}.{plugin_version}"
     plugin_zip_path = os.path.join(this_dir, zip_filename)
     shutil.make_archive(plugin_zip_path, 'zip', this_dir, plugin_dirname)
     print('ZIPPING PLUGIN FINISHED')


### PR DESCRIPTION
This is because the artifact-handler expects a dot.