### PR TITLE
use name__icontains in ThreediCalls.fetch_3di_models()

### DIFF
--- a/threedi_api_qgis_client/api_calls/threedi_calls.py
+++ b/threedi_api_qgis_client/api_calls/threedi_calls.py
@@ -116,7 +116,7 @@ class ThreediCalls:
         if offset is not None:
             params["offset"] = offset
         if name_contains is not None:
-            params["name__contains"] = name_contains.lower()
+            params["name__icontains"] = name_contains.lower()
         logger.debug("Fetching 3di models for current user...")
         response = api.threedimodels_list(**params)
         models_list = response.results


### PR DESCRIPTION
use name__icontains in ThreediCalls.fetch_3di_models() instead of name__contains.

I guess it would be better to refactor all related uses of 'name_contains' to 'name_icontains', but I'd rather not attempt that myself.

fixes #182 