### PR TITLE
Reload schematisation after upload to ensure the gpkg is used

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 
 - Add additional check to deal with legacy gpkgs created by schematisation editor.
 - New schematisation from existing file - move migration logic to after users have clicked Create schematisation (#671)
+- Fix upgrading of schematisation before uploading
 
 
 3.17 (2025-04-02)

--- a/threedi_models_and_simulations/widgets/upload_wizard.py
+++ b/threedi_models_and_simulations/widgets/upload_wizard.py
@@ -174,6 +174,7 @@ class CheckModelWidget(uicls_check_page, basecls_check_page):
             if not migration_succeed:
                 self.communication.show_error(migration_feedback_msg, self)
                 return
+            threedi_db = ThreediDatabase(self.schematisation_filepath.rsplit(".", 1)[0] + ".gpkg")
         except Exception as e:
             error_msg = f"{e}"
             self.communication.show_error(error_msg, self)


### PR DESCRIPTION
Before `migrate_schematisation_schema` upgrades the schematisation, a `ThreediDatabase` instance `threedi_db` was already created. After the upgrade this instance was used again. Because `migrate_schematisation_schema` uses the schematisation path and not `threedi_db`, `threedi_db.path` still referred to the the sqlite.

This is fixed by recreating `threedi_db` after a succesfull upgrade.